### PR TITLE
Updated website header to group header

### DIFF
--- a/src/lib/Header.svelte
+++ b/src/lib/Header.svelte
@@ -5,7 +5,7 @@
 </script>
 
 <header>
-    <h1><a href="/">The GPTs Disaster Management System</a></h1>
+    <h1><a href="/">The Anti-Statics Disaster Management System</a></h1>
 
     <nav>
         <ul>


### PR DESCRIPTION
References issue: #19 

Header will now be updated to that of the group header:

![image](https://github.com/user-attachments/assets/a88bb566-9010-4987-a351-4fac343ca077)
