### PR TITLE
Added alerts post validation message to alerts posting page

### DIFF
--- a/src/routes/alert_system/+page.svelte
+++ b/src/routes/alert_system/+page.svelte
@@ -18,9 +18,11 @@
   const submitAlert = async (event) => {
     event.preventDefault(); // Prevent the form from refreshing the page
 
+    let formattedTitle = isNaN(title) ? title : Number(title); //Check if the title contains numbers or not
+
     // Form data object
     const alertData = {
-      title,
+      title: formattedTitle,
       emergencyType: type,   // Assuming you are using 'emergencyType' on the backend
       alertLevel: level,
       region,

--- a/src/routes/alert_system/post-functions/postAlert.js
+++ b/src/routes/alert_system/post-functions/postAlert.js
@@ -11,12 +11,15 @@ export async function postAlert(alertData) {
       body: JSON.stringify(alertData),
     });
 
-    if (!response.ok) {
-      return { postError: "Failed to post alert. Please try again later." };
+    const data = await response.json();
+
+    //Return the validation message
+    if (!response.ok) { 
+      return { error: data.message };
     }
 
-    const data = await response.json();
-    return { data }; // Return the response data (e.g., the created alert)
+    return { data: data }; // Return the data
+
   } catch (error) {
     //Console the error
     console.log(error);


### PR DESCRIPTION
When incorrectly passing title as a number, the post validation message from the back-end API will now show on the alerts posting page. 